### PR TITLE
Ensure only one SC is marked as "default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Component name ([#2])
 - Disable Kapitan plugin ([#4])
+- Non-default StorageClasses have their "is-default-class" annotation removed ([#7])
 
 ### Fixed
 
@@ -25,3 +26,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/projectsyn/component-storageclass/pull/3
 [#4]: https://github.com/projectsyn/component-storageclass/pull/4
 [#6]: https://github.com/projectsyn/component-storageclass/pull/6
+[#7]: https://github.com/projectsyn/component-storageclass/pull/7

--- a/lib/storageclass.libsonnet
+++ b/lib/storageclass.libsonnet
@@ -20,7 +20,7 @@ local params = inv.parameters.storageclass;
 local storageClass(name) = kube._Object('storage.k8s.io/v1', 'StorageClass', name) {
   metadata+: {
     annotations+: {
-      [if params.defaultClass == name then 'storageclass.kubernetes.io/is-default-class']: 'true',
+      'storageclass.kubernetes.io/is-default-class': if params.defaultClass == name then 'true' else null,
     },
   },
 } + params.defaults;


### PR DESCRIPTION
If there are multiple storageclasses that have the "is-default-class"
annotation set to 'true', provisioning new PVs will fail for PVCs
without an explicit SC set.

This commit aims to ensure that said annotation is automatically removed
from classes that are managed by Syn but are NOT the default.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Update the ./CHANGELOG.md.
