### PR TITLE
Remove the `is-default-class` annotation completely if it's set to `null`

### DIFF
--- a/lib/storageclass.libsonnet
+++ b/lib/storageclass.libsonnet
@@ -19,9 +19,9 @@ local params = inv.parameters.storageclass;
   */
 local storageClass(name) = kube._Object('storage.k8s.io/v1', 'StorageClass', name) {
   metadata+: {
-    annotations+: {
+    annotations+: std.prune({
       'storageclass.kubernetes.io/is-default-class': if params.defaultClass == name then 'true' else null,
-    },
+    }),
   },
 } + params.defaults;
 


### PR DESCRIPTION
This should ensure that ArgoCD can sync non-default storageclasses correctly.

Fixes the change introduced in #7.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.
